### PR TITLE
Mouse reporting toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,8 @@
 Original readme [here](README.md).
 
 This fork contains my personal modifications to xterm.js that are not approved by upstream maintainers.
+
+## Changes Made
+
+- **Added an option to disable mouse reporting.**
+  If this option is enabled, this will allow scrollback and selection on terminal apps, even those that requires mouse reporting (e.g. `tmux` and `vim`).

--- a/src/browser/Terminal.ts
+++ b/src/browser/Terminal.ts
@@ -117,6 +117,8 @@ export class Terminal extends CoreTerminal implements ITerminal {
    */
   private _unprocessedDeadKey: boolean = false;
 
+  private _activeMouseEvents: CoreMouseEventType = CoreMouseEventType.NONE;
+
   public linkifier2: ILinkifier2;
   public viewport: IViewport | undefined;
   private _compositionHelper: ICompositionHelper | undefined;
@@ -671,6 +673,53 @@ export class Terminal extends CoreTerminal implements ITerminal {
       });
     }
 
+    function mouseProtocolChangeHandler(events: CoreMouseEventType) {
+      // apply global changes on events
+      if (events) {
+        if (self.optionsService.rawOptions.logLevel === 'debug') {
+          self._logService.debug('Binding to mouse events:', self.coreMouseService.explainEvents(events));
+        }
+        self.element!.classList.add('enable-mouse-events');
+        self._selectionService!.disable();
+      } else {
+        self._logService.debug('Unbinding from mouse events.');
+        self.element!.classList.remove('enable-mouse-events');
+        self._selectionService!.enable();
+      }
+
+      // add/remove handlers from requestedEvents
+
+      if (!(events & CoreMouseEventType.MOVE)) {
+        el.removeEventListener('mousemove', requestedEvents.mousemove!);
+        requestedEvents.mousemove = null;
+      } else if (!requestedEvents.mousemove) {
+        el.addEventListener('mousemove', eventListeners.mousemove);
+        requestedEvents.mousemove = eventListeners.mousemove;
+      }
+
+      if (!(events & CoreMouseEventType.WHEEL)) {
+        el.removeEventListener('wheel', requestedEvents.wheel!);
+        requestedEvents.wheel = null;
+      } else if (!requestedEvents.wheel) {
+        el.addEventListener('wheel', eventListeners.wheel, { passive: false });
+        requestedEvents.wheel = eventListeners.wheel;
+      }
+
+      if (!(events & CoreMouseEventType.UP)) {
+        self._document!.removeEventListener('mouseup', requestedEvents.mouseup!);
+        requestedEvents.mouseup = null;
+      } else if (!requestedEvents.mouseup) {
+        requestedEvents.mouseup = eventListeners.mouseup;
+      }
+
+      if (!(events & CoreMouseEventType.DRAG)) {
+        self._document!.removeEventListener('mousemove', requestedEvents.mousedrag!);
+        requestedEvents.mousedrag = null;
+      } else if (!requestedEvents.mousedrag) {
+        requestedEvents.mousedrag = eventListeners.mousedrag;
+      }
+    }
+
     /**
      * Event listener state handling.
      * We listen to the onProtocolChange event of CoreMouseService and put
@@ -714,51 +763,17 @@ export class Terminal extends CoreTerminal implements ITerminal {
         }
       }
     };
-    this.register(this.coreMouseService.onProtocolChange(events => {
-      // apply global changes on events
-      if (events) {
-        if (this.optionsService.rawOptions.logLevel === 'debug') {
-          this._logService.debug('Binding to mouse events:', this.coreMouseService.explainEvents(events));
-        }
-        this.element!.classList.add('enable-mouse-events');
-        this._selectionService!.disable();
-      } else {
-        this._logService.debug('Unbinding from mouse events.');
-        this.element!.classList.remove('enable-mouse-events');
-        this._selectionService!.enable();
+    this.register(this.coreMouseService.onProtocolChange((events) => {
+      this._activeMouseEvents = events;
+      if (!this.optionsService.rawOptions.allowMouseReporting) {
+        events = CoreMouseEventType.NONE;
       }
-
-      // add/remove handlers from requestedEvents
-
-      if (!(events & CoreMouseEventType.MOVE)) {
-        el.removeEventListener('mousemove', requestedEvents.mousemove!);
-        requestedEvents.mousemove = null;
-      } else if (!requestedEvents.mousemove) {
-        el.addEventListener('mousemove', eventListeners.mousemove);
-        requestedEvents.mousemove = eventListeners.mousemove;
-      }
-
-      if (!(events & CoreMouseEventType.WHEEL)) {
-        el.removeEventListener('wheel', requestedEvents.wheel!);
-        requestedEvents.wheel = null;
-      } else if (!requestedEvents.wheel) {
-        el.addEventListener('wheel', eventListeners.wheel, { passive: false });
-        requestedEvents.wheel = eventListeners.wheel;
-      }
-
-      if (!(events & CoreMouseEventType.UP)) {
-        this._document!.removeEventListener('mouseup', requestedEvents.mouseup!);
-        requestedEvents.mouseup = null;
-      } else if (!requestedEvents.mouseup) {
-        requestedEvents.mouseup = eventListeners.mouseup;
-      }
-
-      if (!(events & CoreMouseEventType.DRAG)) {
-        this._document!.removeEventListener('mousemove', requestedEvents.mousedrag!);
-        requestedEvents.mousedrag = null;
-      } else if (!requestedEvents.mousedrag) {
-        requestedEvents.mousedrag = eventListeners.mousedrag;
-      }
+      mouseProtocolChangeHandler(events);
+    }));
+    this.register(this.optionsService.onOptionChange(() => {
+      let events = this.optionsService.rawOptions.allowMouseReporting ?
+        this._activeMouseEvents : CoreMouseEventType.NONE;
+      mouseProtocolChangeHandler(events);
     }));
     // force initial onProtocolChange so we dont miss early mouse requests
     this.coreMouseService.activeProtocol = this.coreMouseService.activeProtocol;

--- a/src/browser/Terminal.ts
+++ b/src/browser/Terminal.ts
@@ -807,13 +807,15 @@ export class Terminal extends CoreTerminal implements ITerminal {
           return;
         }
 
-        // Construct and send sequences
-        const sequence = C0.ESC + (this.coreService.decPrivateModes.applicationCursorKeys ? 'O' : '[') + (ev.deltaY < 0 ? 'A' : 'B');
-        let data = '';
-        for (let i = 0; i < Math.abs(amount); i++) {
-          data += sequence;
+        if (this.optionsService.rawOptions.allowMouseReporting) {
+          // Construct and send sequences
+          const sequence = C0.ESC + (this.coreService.decPrivateModes.applicationCursorKeys ? 'O' : '[') + (ev.deltaY < 0 ? 'A' : 'B');
+          let data = '';
+          for (let i = 0; i < Math.abs(amount); i++) {
+            data += sequence;
+          }
+          this.coreService.triggerDataEvent(data, true);
         }
-        this.coreService.triggerDataEvent(data, true);
         return this.cancel(ev, true);
       }
 

--- a/src/browser/services/SelectionService.ts
+++ b/src/browser/services/SelectionService.ts
@@ -427,6 +427,10 @@ export class SelectionService extends Disposable implements ISelectionService {
    * @param event The mouse event.
    */
   public shouldForceSelection(event: MouseEvent): boolean {
+    if (!this._optionsService.rawOptions.allowMouseReporting) {
+      return true;
+    }
+
     if (Browser.isMac) {
       return event.altKey && this._optionsService.rawOptions.macOptionClickForcesSelection;
     }

--- a/src/common/services/OptionsService.ts
+++ b/src/common/services/OptionsService.ts
@@ -38,6 +38,7 @@ export const DEFAULT_OPTIONS: Readonly<Required<ITerminalOptions>> = {
   disableStdin: false,
   allowProposedApi: false,
   allowTransparency: false,
+  allowMouseReporting: true,
   tabStopWidth: 8,
   theme: {},
   rightClickSelectsWord: isMac,

--- a/src/common/services/Services.ts
+++ b/src/common/services/Services.ts
@@ -218,6 +218,7 @@ export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'off';
 export interface ITerminalOptions {
   allowProposedApi?: boolean;
   allowTransparency?: boolean;
+  allowMouseReporting?: boolean;
   altClickMovesCursor?: boolean;
   cols?: number;
   convertEol?: boolean;

--- a/typings/xterm-headless.d.ts
+++ b/typings/xterm-headless.d.ts
@@ -32,6 +32,12 @@ declare module 'xterm-headless' {
     allowTransparency?: boolean;
 
     /**
+     * If enabled, mouse events will be forwarded to the program running
+     * inside the terminal. The default is true.
+     */
+    allowMouseReporting?: boolean;
+
+    /**
      * If enabled, alt + click will move the prompt cursor to position
      * underneath the mouse. The default is true.
      */

--- a/typings/xterm.d.ts
+++ b/typings/xterm.d.ts
@@ -39,6 +39,12 @@ declare module 'xterm' {
     allowTransparency?: boolean;
 
     /**
+     * If enabled, mouse events will be forwarded to the program running
+     * inside the terminal. The default is true.
+     */
+    allowMouseReporting?: boolean;
+
+    /**
      * If enabled, alt + click will move the prompt cursor to position
      * underneath the mouse. The default is true.
      */


### PR DESCRIPTION
This PR adds toggle to disable mouse reporting completely. This will enable scrolling and native selection, even on apps that requires mouse reporting such as `tmux` and `vim`.